### PR TITLE
Fix: Fetch JWT token from UserPreferences

### DIFF
--- a/app/src/main/java/com/crm/edu/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/crm/edu/core/network/AuthInterceptor.kt
@@ -1,18 +1,26 @@
 package com.crm.edu.core.network
 
+import com.crm.edu.data.login.local.pref.UserPreferences
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import javax.inject.Inject
 
 class AuthInterceptor @Inject constructor(
-    private val token: String
+    private val userPreferences: UserPreferences
 ): Interceptor {
 
+    private var jwtToken: String? = null
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest: Request = chain.request()
+        if(jwtToken == null){
+            jwtToken = runBlocking {
+                userPreferences.getJWTtoken()
+            }
+        }
         val authenticatedRequest = originalRequest.newBuilder()
-            .header("Authorization", "Bearer $token")
+            .header("Authorization", "Bearer $jwtToken")
             .build()
         return chain.proceed(authenticatedRequest)
     }

--- a/app/src/main/java/com/crm/edu/data/login/local/pref/UserPreference.kt
+++ b/app/src/main/java/com/crm/edu/data/login/local/pref/UserPreference.kt
@@ -60,6 +60,15 @@ class UserPreferences(context: Context) {
             .first()
     }
 
+    // Suspend function to get the reporting ID directly
+    suspend fun getJWTtoken(): String? {
+        return dataStore.data
+            .map { preferences ->
+                preferences[UserPreferencesKeys.JWT_TOKEN]
+            }
+            .first()
+    }
+
     // Save User Data
     suspend fun saveUserData(userData: Map<String, String>) {
         dataStore.edit { preferences ->
@@ -115,6 +124,12 @@ class UserPreferences(context: Context) {
                         value
 
                     UserPreferencesKeys.DEPARTMENT.name -> preferences[UserPreferencesKeys.DEPARTMENT] =
+                        value
+
+                    UserPreferencesKeys.LOGIN_TOKEN.name -> preferences[UserPreferencesKeys.LOGIN_TOKEN] =
+                        value
+
+                    UserPreferencesKeys.JWT_TOKEN.name -> preferences[UserPreferencesKeys.JWT_TOKEN] =
                         value
                 }
             }

--- a/app/src/main/java/com/crm/edu/di/AppModule.kt
+++ b/app/src/main/java/com/crm/edu/di/AppModule.kt
@@ -49,9 +49,10 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideAuthInterceptor(): AuthInterceptor {
-        return AuthInterceptor("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsb2dpbl90b2tlbiI6ImY0YmRmODlmMWI5NmI5NWFlMjRlMmQ4YWVhODkwZTdjIiwiaWF0IjoxNzIzNjkyMjE3LCJleHAiOjE3Mjg4NzYyMTd9.Lr1l2IjqRMXG5fEHVew4dY-M6mft01V7PGz_d_Yc0jM")
+    fun provideAuthInterceptor(userPreferences: UserPreferences): AuthInterceptor {
+        return AuthInterceptor(userPreferences)
     }
+
 
     @Provides
     @Singleton


### PR DESCRIPTION
Modified AuthInterceptor to fetch the JWT token from UserPreferences instead of using a hardcoded value. Updated AppModule to
 provide UserPreferences to AuthInterceptor.
Added a suspend function to UserPreference to retrieve the JWT token directly.