### PR TITLE
Feat: Navigate to CalendarV2 with staffId

### DIFF
--- a/app/src/main/java/com/crm/edu/data/myteam/ModelMapper.kt
+++ b/app/src/main/java/com/crm/edu/data/myteam/ModelMapper.kt
@@ -9,5 +9,6 @@ fun StaffDTO.asEntity() = StaffAttendanceEntity(
     start = start,
     colour = colour,
     designation = designation,
-    staff_name = staffName
+    staff_name = staffName,
+    staff_id = staffId
 )

--- a/app/src/main/java/com/crm/edu/data/myteam/MyTeamData.kt
+++ b/app/src/main/java/com/crm/edu/data/myteam/MyTeamData.kt
@@ -7,4 +7,5 @@ data class StaffAttendanceData(
     val colour: String,
     val designation: String,
     val staffName: String,
+    val staffId: String,
 )

--- a/app/src/main/java/com/crm/edu/data/myteam/local/MyTeamEntity.kt
+++ b/app/src/main/java/com/crm/edu/data/myteam/local/MyTeamEntity.kt
@@ -19,6 +19,8 @@ data class StaffAttendanceEntity(
     val designation: String,
     @ColumnInfo(defaultValue = "")
     val staff_name: String,
+    @ColumnInfo(defaultValue = "")
+    val staff_id: String,
 ) {
     @PrimaryKey(autoGenerate = true)
     var autoId: Long = 0
@@ -30,5 +32,6 @@ fun StaffAttendanceEntity.asExternalModel() = StaffAttendanceData(
     start = start,
     colour = colour,
     designation = designation,
-    staffName = staff_name
+    staffName = staff_name,
+    staffId = staff_id
 )

--- a/app/src/main/java/com/crm/edu/data/myteam/remote/StaffAttendanceDTO.kt
+++ b/app/src/main/java/com/crm/edu/data/myteam/remote/StaffAttendanceDTO.kt
@@ -18,5 +18,6 @@ data class StaffDTO(
     @SerialName("colour") val colour: String,
     @SerialName("designation") val designation: String,
     @SerialName("staff_name") val staffName: String,
+    @SerialName("staff_id") val staffId: String = "",
 )
 

--- a/app/src/main/java/com/crm/edu/ui/compose/Screen.kt
+++ b/app/src/main/java/com/crm/edu/ui/compose/Screen.kt
@@ -13,5 +13,5 @@ sealed class Screen(val route: String) {
     data object Leaves : Screen("leaves_screen")
     data object Calendar : Screen("calendar_screen")
     data object MyTeam : Screen("my_team_screen")
-    data object CalendarV2 : Screen("calendar_v2_screen")
+    data object CalendarV2 : Screen("calendar_v2_screen?staffId={staffId}")
 }

--- a/app/src/main/java/com/crm/edu/ui/compose/screens/BottomNavigationBar.kt
+++ b/app/src/main/java/com/crm/edu/ui/compose/screens/BottomNavigationBar.kt
@@ -17,8 +17,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.crm.edu.ui.compose.Screen
 import com.crm.edu.ui.compose.screens.attendance.AttendanceScreen
 import com.crm.edu.ui.compose.screens.calendar.CalendarScreen
@@ -127,12 +129,23 @@ fun BottomNavigationBar(navController: NavHostController) {
                 }
             }
             composable(route = Screen.MyTeam.route) {
-                MyTeamScreen(navController = navController){
-                    navController.navigateUp()
-                }
+                MyTeamScreen(
+                    navController = navController,
+                    onUpClick = { navController.navigateUp() },
+                    onTeamMemberSelected = {
+                        val route = Screen.CalendarV2.route.replace("{staffId}", it)
+                        navController.navigate(route = route)
+                    })
             }
-            composable(route = Screen.CalendarV2.route) {
-                AttendanceScreenWithCalendarView(navController = navController) {
+            composable(route = Screen.CalendarV2.route, arguments = listOf(
+                navArgument("staffId") {
+                    defaultValue = "default"
+                    type = NavType.StringType
+                }
+            )) { navBackStackEntry ->
+                /* Extracting the id from the route */
+                val staffId = navBackStackEntry.arguments?.getString("staffId")
+                AttendanceScreenWithCalendarView(staffId = staffId, navController = navController) {
                     navController.navigateUp()
                 }
             }

--- a/app/src/main/java/com/crm/edu/ui/compose/screens/calendarv2/AttendanceScreenWithCalendarView.kt
+++ b/app/src/main/java/com/crm/edu/ui/compose/screens/calendarv2/AttendanceScreenWithCalendarView.kt
@@ -34,6 +34,7 @@ import java.util.Date
 
 @Composable
 fun AttendanceScreenWithCalendarView(
+    staffId: String? = null,
     navController: NavHostController,
     viewModel: AttendanceScreenWithCalendarViewModel = hiltViewModel(),
     onUpClick: () -> Unit = {},
@@ -109,7 +110,7 @@ private fun TopBar(
 @Composable
 fun PreviewAttendanceScreenWithCalendarView() {
     val navController = rememberNavController()
-    AttendanceScreenWithCalendarView(navController)
+    AttendanceScreenWithCalendarView(navController = navController)
 }
 
 

--- a/app/src/main/java/com/crm/edu/ui/compose/screens/myteam/MyTeamScreen.kt
+++ b/app/src/main/java/com/crm/edu/ui/compose/screens/myteam/MyTeamScreen.kt
@@ -2,6 +2,7 @@ package com.crm.edu.ui.compose.screens.myteam
 
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,22 +43,16 @@ import androidx.navigation.NavHostController
 import com.crm.edu.R
 import com.crm.edu.data.myteam.StaffAttendanceData
 
-data class TeamMember(
-    val name: String,
-    val role: String,
-    val checkedIn: Boolean,
-    val time: String
-)
-
 
 @Composable
 fun MyTeamScreen(
     navController: NavHostController,
     viewModel: MyTeamScreenViewModel = hiltViewModel(),
     onUpClick: () -> Unit = {},
+    onTeamMemberSelected: (staffId: String) -> Unit = {}
 ) {
     val state by viewModel.uiState.collectAsState()
-    MyTeamScreenInternal(navController, viewModel, state, onUpClick)
+    MyTeamScreenInternal(navController, viewModel, state, onUpClick, onTeamMemberSelected)
 }
 
 @Composable
@@ -66,6 +61,7 @@ private fun MyTeamScreenInternal(
     viewModel: MyTeamScreenViewModel,
     state: UIState,
     onUpClick: () -> Unit,
+    onTeamMemberSelected: (staffId: String) -> Unit
 ) {
     Scaffold(
         topBar = {
@@ -83,7 +79,7 @@ private fun MyTeamScreenInternal(
                         viewModel.fetchStaffAttendance()
                     }
                 } else {
-                    TeamList(padding, members = state.data.staffList)
+                    TeamList(padding, members = state.data.staffList, onTeamMemberSelected)
                 }
             }
 
@@ -116,14 +112,20 @@ private fun ErrorScreen(message: String, showRetry: Boolean = true, onRetry: () 
 
 
 @Composable
-private fun TeamList(padding: PaddingValues = PaddingValues(), members: List<StaffAttendanceData>) {
+private fun TeamList(
+    padding: PaddingValues = PaddingValues(),
+    members: List<StaffAttendanceData>,
+    onTeamMemberSelected: (staffId: String) -> Unit = {}
+) {
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(padding)
     ) {
         items(members.size) { index ->
-            TeamMemberItem(member = members[index])
+            TeamMemberItem(
+                member = members[index],
+                onItemClick = { onTeamMemberSelected.invoke(it.staffId) })
         }
     }
 }
@@ -143,13 +145,20 @@ private fun LoadingLayout(paddingValues: PaddingValues = PaddingValues()) {
 
 
 @Composable
-private fun TeamMemberItem(member: StaffAttendanceData) {
+private fun TeamMemberItem(
+    member: StaffAttendanceData,
+    onItemClick: (StaffAttendanceData) -> Unit
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(8.dp)
-            .background(Color.White, shape = RoundedCornerShape(8.dp)),
-        verticalAlignment = Alignment.CenterVertically
+            .background(Color.White, shape = RoundedCornerShape(8.dp))
+            .clickable {
+                // Handle item click
+                onItemClick.invoke(member)
+            },
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
             modifier = Modifier
@@ -195,7 +204,8 @@ private fun getTeamList(): List<StaffAttendanceData> {
             start = "2024-08-15",
             colour = "#F4DDE5",
             designation = "Assistant",
-            staffName = "Sakshi Khurana"
+            staffName = "Sakshi Khurana",
+            staffId = "123"
         )
     )
 }


### PR DESCRIPTION
Added functionality to navigate to the CalendarV2 screen with the selected staff member's ID. Included
 staffId in StaffAttendanceDTO, MyTeamEntity, and MyTeamData.
Updated MyTeamScreen to handle item clicks and pass staffId to CalendarV2. Modified BottomNavigationBar to pass staffId as an argument to CalendarV2 route.